### PR TITLE
Fix karo errors

### DIFF
--- a/bin/karo
+++ b/bin/karo
@@ -8,5 +8,6 @@ rescue SystemExit, Interrupt
   STDERR.puts "Exiting"
 rescue => e
   STDERR.puts "karo: Error: #{e}"
+  STDERR.puts e.backtrace
   exit 1
 end

--- a/bin/karo
+++ b/bin/karo
@@ -6,7 +6,7 @@ begin
   Karo::CLI.start(ARGV)
 rescue SystemExit, Interrupt
   STDERR.puts "Exiting"
-rescue Exception => e
+rescue => e
   STDERR.puts "karo: Error: #{e}"
   exit 1
 end

--- a/bin/karo
+++ b/bin/karo
@@ -8,5 +8,5 @@ rescue SystemExit, Interrupt
   STDERR.puts "Exiting"
 rescue Exception => e
   STDERR.puts "karo: Error: #{e}"
-  return 1
+  exit 1
 end

--- a/lib/karo/common.rb
+++ b/lib/karo/common.rb
@@ -22,7 +22,7 @@ module Karo
     def run_it(cmd, verbose=false)
       say cmd, :green if verbose
       system cmd unless options[:dryrun]
-      if $?.exitstatus
+      if $?.exitstatus != 0
         raise "Non-zero exit code (#{$?.exitstatus}) returned from #{cmd.strip}"
       end
     end


### PR DESCRIPTION
This pull request is to resolve the following errors which were encountered when running a deploy via a Jenkins build.

```
karo: Error: Non-zero exit code (0) returned from ey deploy --force-ref $DEPLOY_BRANCH --migrate -e $DEPLOY_ENV -a $DEPLOY_APP
/Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bundler/gems/karo-e1efcd214dfa/bin/karo:11:in `rescue in <top (required)>': unexpected return (LocalJumpError)
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bundler/gems/karo-e1efcd214dfa/bin/karo:5:in `<top (required)>'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/karo:23:in `load'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/karo:23:in `<main>'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `eval'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `<main>'
```

and...

```
karo: Error: Non-zero exit code (1) returned from DEPLOY_APP=meecoapi_test_ie DEPLOY_ENV=meecodev_ie DEPLOY_BRANCH=${DEPLOY_BRANCH:-develop} karo client perform_deploy -e testing
/Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bundler/gems/karo-e1efcd214dfa/bin/karo:11:in `rescue in <top (required)>': unexpected return (LocalJumpError)
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bundler/gems/karo-e1efcd214dfa/bin/karo:5:in `<top (required)>'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/karo:23:in `load'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/karo:23:in `<main>'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `eval'
	from /Users/Shared/Jenkins/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `<main>'
```

There are two issues being resolved by this pull request:
* `karo: Error: Non-zero exit code (0) returned` indicates that an exit status of `0` is being marked as an error state.
*  `unexpected return (LocalJumpError)` indicates that `return` is being used in a place where it cant be used.